### PR TITLE
ci: dual-deploy to Cloudflare Pages alongside Azure

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -65,6 +65,17 @@ jobs:
           inlineScript: |
             az cdn endpoint purge --content-paths  "/*" --profile-name ${{ env.AZURE_CDN_PROFILE }} --name ${{ env.AZURE_CDN_ENDPOINT }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }}
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      # Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages
+      # is verified; a follow-up PR removes the Azure step afterwards.
+      - name: Deploy to Cloudflare Pages (DEV)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy build --project-name=dfx-exchange-dev --branch=develop
+
       - name: Logout
         run: |
           az logout

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -65,6 +65,13 @@ jobs:
           inlineScript: |
             az cdn endpoint purge --content-paths  "/*" --profile-name ${{ env.AZURE_CDN_PROFILE }} --name ${{ env.AZURE_CDN_ENDPOINT }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }}
 
+      # wrangler@4 requires Node >= 18; the app build above runs on Node 16, so
+      # bump Node only for the Wrangler steps without touching the CRA build.
+      - name: Use Node.js 20 for Wrangler
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Install Wrangler
         run: npm install -g wrangler@4
 

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -65,6 +65,13 @@ jobs:
           inlineScript: |
             az cdn endpoint purge --content-paths  "/*" --profile-name ${{ env.AZURE_CDN_PROFILE }} --name ${{ env.AZURE_CDN_ENDPOINT }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }}
 
+      # wrangler@4 requires Node >= 18; the app build above runs on Node 16, so
+      # bump Node only for the Wrangler steps without touching the CRA build.
+      - name: Use Node.js 20 for Wrangler
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
       - name: Install Wrangler
         run: npm install -g wrangler@4
 

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -65,6 +65,17 @@ jobs:
           inlineScript: |
             az cdn endpoint purge --content-paths  "/*" --profile-name ${{ env.AZURE_CDN_PROFILE }} --name ${{ env.AZURE_CDN_ENDPOINT }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }}
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      # Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages
+      # is verified; a follow-up PR removes the Azure step afterwards.
+      - name: Deploy to Cloudflare Pages (PRD)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy build --project-name=dfx-exchange-prd --branch=main
+
       - name: Logout
         run: |
           az logout

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,17 @@
+# Cloudflare Pages edge headers — replicate the cache semantics the previous
+# CDN served, so the Pages deployment behaves identically.
+#
+# Fingerprinted build assets (content-hashed filenames) never change -> cache hard.
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+# Entry points must always revalidate so a new deploy goes live immediately.
+/
+  Cache-Control: no-cache, must-revalidate
+/index.html
+  Cache-Control: no-cache, must-revalidate
+/manifest.json
+  Cache-Control: no-cache, must-revalidate
+/asset-manifest.json
+  Cache-Control: no-cache, must-revalidate

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+# SPA deep-link fallback: unknown paths serve the app shell (client-side routing).
+# Real files (static/*, favicon, ...) are matched by the host first.
+/*    /index.html    200


### PR DESCRIPTION
## What

Deploys the exchange app to **Cloudflare Pages** in addition to the existing Azure Blob upload (dual-deploy), and adds the Pages edge config (`public/_headers`, `public/_redirects`).

## Why

`exchange.dfx.swiss` is being migrated off Azure Front Door onto Cloudflare Pages. To avoid any window where the live app goes stale, this is a **dual-deploy transition**: every push keeps deploying to Azure *and* now also to the Pages projects. Once the DNS cutover to Pages is verified, a follow-up PR removes the Azure steps.

## Changes

- **`prd.yml` / `dev.yml`**: before the final `always()` Logout step, two new steps — install `wrangler@4` and `wrangler pages deploy build --project-name=<proj> --branch=<branch>`:
  - PRD → `dfx-exchange-prd` / `main`
  - DEV → `dfx-exchange-dev` / `develop`
  - Auth via repo secrets `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` (already set).
- **`public/_headers`** (CRA copies `public/*` into `build/`): `/static/*` immutable + CORS, entry points `no-cache, must-revalidate`.
- **`public/_redirects`**: `/* /index.html 200` — SPA deep-link fallback.

## Not in this PR

- Removing the Azure deploy (follow-up, after the DNS cutover is verified).
- The DNS flip / Pages custom-domain attach (infra side).

## Verification

Draft until a preview deploy on the Pages project has been verified. The existing PR CI (lint/test/build) covers the build with the new `public/` files.
